### PR TITLE
Missing requirement: django-uni-form

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ django-jsonfield
 django-picklefield
 django-allauth
 django-honeypot
+django-uni-form
 
 python-memcached
 piwik


### PR DESCRIPTION
django-uni-form was not listed in requirements.txt and it wasn't installed. 
That caused an error when calling `./wolnelektury/manage.py syncdb`:

```
 ImportError uni_form: No module named uni_form
```
